### PR TITLE
elfcore.c: do not use sizeof with VLA

### DIFF
--- a/src/elfcore.c
+++ b/src/elfcore.c
@@ -1196,8 +1196,8 @@ static int CreateElfCore(void *handle,
         /* Align all following segments to multiples of page size            */
         if (note_align) {
           char scratch[note_align];
-          memset(scratch, 0, sizeof(scratch));
-          if (writer(handle, scratch, sizeof(scratch)) != sizeof(scratch)) {
+          memset(scratch, 0, note_align*sizeof(char));
+          if (writer(handle, scratch, note_align*sizeof(char)) != note_align*sizeof(char)) {
             goto done;
           }
         }


### PR DESCRIPTION
Expression sizeof(scratch) doesn't work properly when using --std=c++1y in g++ 4.9. It seems that in this mode g++ assumes it is a constant-time expression equal to sizeof(char) instead of substituting the run-time value of the variable-length array size, leading to the malformed core dump.

/cc: @anatol 